### PR TITLE
Png fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,42 @@
+#Byte-compiled / optimized / DLL files
 .cache/
 .pytest_cache/
 __pycache__/
 *.py[cod]
 
+# C extensions
+*.so
+
+# Distribution / packaging
+bin/
+build/
+develop-eggs/
+dist/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+
+# Others
 tests/test_img.vox
 tests/test_img.png
 tests/test_img.gslib

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "3.6"
 before_install:
-  - pip install pytest pytest-cov
+  - pip install -U pytest pytest-cov
   - pip install coveralls
 install:
   - pip install numpy
@@ -13,6 +13,6 @@ install:
   - pip install -e .
 script:
   - pytest --cov=mpstool
-  - pycodestyle mpstool tests 
+  - pycodestyle mpstool tests
 after_success:
   - coveralls

--- a/mpstool/img.py
+++ b/mpstool/img.py
@@ -327,7 +327,7 @@ class Image:
     # ------ Png ------
 
     @staticmethod
-    def fromPng(file_name: str, normalize=False):
+    def fromPng(file_name: str, normalize=False, channel_mode="RGB"):
         """
         Image staticmethod. Used as an initializer.
         Builds the container from a .png file.
@@ -344,7 +344,12 @@ class Image:
         'normalize' : boolean
             if set to true, the values will be stretched to fit in [-1;1]
 
-        Returns
+        'channel_mode' : string
+            if set to RGB, will extract three variables R,G and B from the image
+            if set to Gray, will perform a grayscale transformation and extract only one variable
+            Default is RGB
+
+        Returnsey
         ----------
         A new Image object
         """
@@ -363,10 +368,16 @@ class Image:
             data = {"V0": ar}
             params = {"is3D": False, "nVariables": 1}
         else:
-            data = {"R": ar[:, :, 0],
-                    "G": ar[:, :, 1],
-                    "B": ar[:, :, 2]}
-            params = {"is3D": False, "nVariables": 3}
+            if channel_mode=="RGB":
+                data = {"R": ar[:, :, 0],
+                        "G": ar[:, :, 1],
+                        "B": ar[:, :, 2]}
+                # Ignore the eventual alpha canal
+                params = {"is3D": False, "nVariables": 3}
+            elif channel_mode=="Gray":
+                gray_ar = 0.29*ar[:,:,0] + 0.58*ar[:,:,1] + 0.13*ar[:,:,2]
+                data = {"V0" : gray_ar}
+                params = {"is3D" : False, "nVariables": 1}
         img = Image(data, params)
         if normalize:
             img.normalize()
@@ -1408,7 +1419,7 @@ class Image:
         """Permutes y and z directions."""
         self._perm(1, 2)
 
-    def get_sample(self, output_dim, var_name: str = None, normalize=False):
+    def get_sample(self, output_dim, var_name: list = None, normalize=False):
         """
         Extract a random submatrix of a given size from the data container.
 
@@ -1422,34 +1433,39 @@ class Image:
             if set to true, apply the normalize method to the output sample to
             get values in [-1;1]
 
-        'var_name' : string
-            the name of the variable in which the sample is taken.
+        'var_name' : list
+            the name of the variables in which the sample is taken.
             Needs to be specified if nvariables>1
 
         Returns
         ----------
-        A new Image object of size 'output_dim'
+        A new Image object of size (output_dim * len(var_name))
         """
-        if var_name is None and self.nvariables > 1:
-            raise UndefVarExc("get_sample")
-        data = self._data[var_name] if var_name is not None else list(
-            self._data.values())[0]
+        if var_name is None:
+            if self.nvariables > 1:
+                raise UndefVarExc("get_sample")
+            var_name = list(self._data.keys())
         xd, yd, zd = output_dim
+        sample = {}
         if self.is3D:
             xs, ys, zs = self.shape
             choice_x = np.random.randint(xs-xd)
             choice_y = np.random.randint(ys-yd)
             choice_z = np.random.randint(zs-zd)
-            sample = data[choice_x:choice_x+xd,
-                          choice_y:choice_y+yd, choice_z:choice_z+zd]
+            for name in var_name:
+                sample[name] = self._data[name][choice_x:choice_x+xd,
+                                                choice_y:choice_y+yd,
+                                                choice_z:choice_z+zd]
         else:
             xs, ys = self.shape[0], self.shape[1]
             choice_x = np.random.randint(xs-xd)
             choice_y = np.random.randint(ys-yd)
-            sample = self._data[choice_x:choice_x +
-                                xd, choice_y:choice_y+yd, 0:1]
+            for name in var_name:
+                sample[name] = self._data[name][choice_x:choice_x+xd,
+                                                choice_y:choice_y+yd,
+                                                0:1]
         params = dict([('is3D', self.is3D)])
-        sample = Image({"V0": sample}, params)
+        sample = Image(sample, params)
         if normalize:
             sample.normalize()
         return sample

--- a/mpstool/img.py
+++ b/mpstool/img.py
@@ -345,8 +345,9 @@ class Image:
             if set to true, the values will be stretched to fit in [-1;1]
 
         'channel_mode' : string
-            if set to RGB, will extract three variables R,G and B from the image
-            if set to Gray, will perform a grayscale transformation and extract only one variable
+            if set to RGB, will extract three variables R,G and B
+            if set to Gray, will perform a grayscale transformation and
+            extract only one variable.
             Default is RGB
 
         Returnsey
@@ -368,16 +369,17 @@ class Image:
             data = {"V0": ar}
             params = {"is3D": False, "nVariables": 1}
         else:
-            if channel_mode=="RGB":
+            if channel_mode == "RGB":
                 data = {"R": ar[:, :, 0],
                         "G": ar[:, :, 1],
                         "B": ar[:, :, 2]}
                 # Ignore the eventual alpha canal
                 params = {"is3D": False, "nVariables": 3}
-            elif channel_mode=="Gray":
-                gray_ar = 0.29*ar[:,:,0] + 0.58*ar[:,:,1] + 0.13*ar[:,:,2]
-                data = {"V0" : gray_ar}
-                params = {"is3D" : False, "nVariables": 1}
+            elif channel_mode == "Gray":
+                gray_ar = 0.29*ar[:, :, 0] + 0.58 * \
+                    ar[:, :, 1] + 0.13*ar[:, :, 2]
+                data = {"V0": gray_ar}
+                params = {"is3D": False, "nVariables": 1}
         img = Image(data, params)
         if normalize:
             img.normalize()

--- a/mpstool/img.py
+++ b/mpstool/img.py
@@ -350,7 +350,7 @@ class Image:
             extract only one variable.
             Default is RGB
 
-        Returnsey
+        Returns
         ----------
         A new Image object
         """
@@ -1362,7 +1362,7 @@ class Image:
                 self._data[key] = self._data[key] / m
             self._data[key] = 2*self._data[key] - 1
 
-    def unnormalize(self, var_names=[], output_type=np.uint8):
+    def unnormalize(self, var_name: list = None, output_type=np.uint8):
         """
         Transformation method. Applies a linear transformation
         to get all data in range [0,255]
@@ -1379,7 +1379,7 @@ class Image:
             normalized
         """
         self.normalize()
-        keys = self._data.keys() if not var_names else var_names
+        keys = self._data.keys() if var_name is None else var_name
         for key in keys:
             self._data[key] = (self._data[key]+1)*127.5
             self._data[key] = self._data[key].astype(output_type)
@@ -1421,7 +1421,9 @@ class Image:
         """Permutes y and z directions."""
         self._perm(1, 2)
 
-    def get_sample(self, output_dim, var_name: list = None, normalize=False):
+    def get_sample(self, output_dim,
+                   var_name: list = None,
+                   normalize: bool = False):
         """
         Extract a random submatrix of a given size from the data container.
 

--- a/mpstool/img.py
+++ b/mpstool/img.py
@@ -102,6 +102,8 @@ class Image:
         if self._data.keys() != other._data.keys():
             return False
         for k in self._data.keys():
+            if self._data[k].shape != other._data[k].shape:
+                return False
             if not np.alltrue(self._data[k] == other._data[k]):
                 return False
         return True

--- a/tests/test_connectivity.py
+++ b/tests/test_connectivity.py
@@ -15,8 +15,8 @@ def array():
 
 
 @pytest.fixture
-def image():
-    return mpstool.img.Image.fromArray(array())
+def image(array):
+    return mpstool.img.Image.fromArray(array)
 
 
 @pytest.fixture
@@ -38,8 +38,8 @@ def cube():
 
 
 @pytest.fixture
-def cube_image():
-    return mpstool.img.Image.fromArray(cube())
+def cube_image(cube):
+    return mpstool.img.Image.fromArray(cube)
 
 
 def test_threshold():
@@ -72,23 +72,23 @@ def test_connected_component(cube):
         cube, background=0) == connectivity_array_cube)
 
 
-def test_categories():
-    assert all(mpstool.connectivity.get_categories(cube()) == [0, 1])
-    assert all(mpstool.connectivity.get_categories(cube_image()) == [0, 1])
+def test_categories(cube, cube_image):
+    assert all(mpstool.connectivity.get_categories(cube) == [0, 1])
+    assert all(mpstool.connectivity.get_categories(cube_image) == [0, 1])
 
 
-def test_get_map():
+def test_get_map(array, image):
     expected_map = {0: np.array([[1., 0.], [0., 0.]]),
                     1: np.array([[0., 0.], [0., 0.]])}
-    for ar in [array(), image()]:
+    for ar in [array, image]:
         real_map = mpstool.connectivity.get_map(ar)
         assert real_map.keys() == expected_map.keys()
         for k in expected_map.keys():
             assert np.alltrue(real_map[k] == expected_map[k])
 
 
-def test_function_2D():
-    for ar in [array(), image()]:
+def test_function_2D(array, image):
+    for ar in [array, image]:
         axis0_connectivity = {0: np.array([1., 0.]), 1: np.array([0., 0.])}
         axis1_connectivity = {0: np.array([1., 1.]), 1: np.array([1., 0.5])}
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -4,18 +4,19 @@ Test module for the Image class. Execute with pytest : `pytest test_image.py`
 
 import numpy as np
 from mpstool.img import *
+from copy import copy, deepcopy
 import pytest
 
 
-def example_image():
+@pytest.fixture
+def img():
     data = np.array([[200, 255, 60],
                      [100, 10, 255],
                      [250, 100, 0]])
     return Image.fromArray(data)
 
 
-def test_threshold1():
-    img = example_image()
+def test_threshold1(img):
     img.threshold(thresholds=[127], values=[0, 255])
     expected = Image.fromArray(
         np.array([[255, 255, 0],
@@ -24,8 +25,7 @@ def test_threshold1():
     assert img == expected
 
 
-def test_threshold2():
-    img = example_image()
+def test_threshold2(img):
     img.threshold(thresholds=[80, 210], values=[0, 127, 255])
     expected = Image.fromArray(
         np.array([[127, 255, 0],
@@ -34,8 +34,7 @@ def test_threshold2():
     assert img == expected
 
 
-def test_saturate():
-    img = example_image()
+def test_saturate(img):
     img.saturate(t=127)
     saturated = img.asArray()
     expected = np.array([[200, 255, 0],
@@ -45,8 +44,7 @@ def test_saturate():
     assert np.alltrue(saturated == expected)
 
 
-def test_labelize():
-    img = example_image()
+def test_labelize(img):
     expected = np.array([[4, 6, 2],
                          [3, 1, 6],
                          [5, 3, 0]])
@@ -67,12 +65,11 @@ def test_from_list():
 
 # ------ Test of conversion functions ------
 
-def test_from_txt():
-    img = Image.fromTxt("tests/data/test_img.txt", (3, 3))
+def test_from_txt(img):
+    img1 = Image.fromTxt("tests/data/test_img.txt", (3, 3))
     img2 = Image.fromTxt("tests/data/test_img.txt", (3, 3, 1))
-    expected = example_image()
+    assert img == img1
     assert img == img2
-    assert img == expected
 
 
 def test_conversion_txt_gslib():
@@ -118,7 +115,7 @@ def test_conversion_png_txt():
 
 
 def test_conversion_final():
-    a = np.loadtxt("tests/data/test_img.txt")
+    a = np.loadtxt("tests/data/test_img.txt").reshape((3, 3))
     b = np.loadtxt("tests/data/test_img2.txt")
     return np.alltrue(a == b)
 
@@ -163,8 +160,7 @@ def test_conversion_color2():
     assert img == img3
 
 
-def test_categorize1():
-    img = example_image()
+def test_categorize1(img):
     expected = Image.fromArray(
         np.array([[255, 255, 100],
                   [100, 100, 255],
@@ -175,8 +171,7 @@ def test_categorize1():
     assert img == expected
 
 
-def test_categorize2():
-    img = example_image()
+def test_categorize2(img):
     expected = Image.fromArray(
         np.array([[255, 255, 100],
                   [100, 0, 255],
@@ -185,14 +180,12 @@ def test_categorize2():
     assert img == expected
 
 
-def test_setters():
-    img = example_image()
+def test_setters(img):
     img.set_dimension((1, 1, 1))
     assert img.shape == (1, 1, 1)
 
 
-def test_dimension():
-    img = example_image()
+def test_dimension(img):
     assert img.nxyz() == 9
     assert img.nxy() == 9
     assert img.nxz() == 3
@@ -212,8 +205,7 @@ def test_dimension():
     assert img.get_variables() == ["V0"]
 
 
-def test_variable():
-    img = example_image()
+def test_variable(img):
     data = np.array([[200, 255, 60],
                      [100, 10, 255],
                      [250, 100, 0]])
@@ -229,28 +221,27 @@ def test_variable():
     assert img.get_variables() == ["V0"]
 
 
-def test_extract():
-    img = example_image()
-    img2 = img.extract_variable(["V0"], copy=False)
-    assert img2 == example_image()
-    assert len(img.get_variables()) == 0
+def test_extract(img):
+    img2 = deepcopy(img).extract_variable(["V0"], copy=False)
+    assert len(img2.get_variables()) == 1
+    assert img2 == img
 
 
-def test_flip():
-    img = example_image()
-    img.flipx()
-    img.flipy()
-    img.flipz()
-    img.flipx()
-    img.flipy()
-    img.flipz()
-    assert img == example_image()
+def test_flip(img):
+    img2 = img
+    img2.flipx()
+    img2.flipy()
+    img2.flipz()
+    img2.flipx()
+    img2.flipy()
+    img2.flipz()
+    assert img2 == img
 
 
-def test_perm():
-    img = example_image()
-    img.permxy()
-    img.permyz()
-    img.permxz()
-    img.permyz()
-    assert img == example_image()
+def test_perm(img):
+    img2 = img
+    img2.permxy()
+    img2.permyz()
+    img2.permxz()
+    img2.permyz()
+    assert img == img2


### PR DESCRIPTION
Small changes with the way PNG files are loaded in the library.

Added an extra argument `channel_mode` that can take values 'RGB' or 'Gray'. If 'RGB' is selected (default), then the program will create three variables inside the image (one per channel). If 'Gray' is selected, only one is created.

Before, the only possible mode was RGB, which caused issues in geode when working with only one channel.

Also, I changed the `get_sample` method to be able to sample on different variables at the same time.