### PR TITLE
correctly implement the set_default_var_name method

### DIFF
--- a/mpstool/img.py
+++ b/mpstool/img.py
@@ -969,14 +969,12 @@ class Image:
 
     def set_default_var_name(self):
         """Sets default variable names: var_name = ('V0', 'V1',...)."""
-        self.var_name = ["V{:d}".format(i) for i in range(self.nvariables)]
-
-    def set_dimension(self, new_size, new_val=0) -> None:
-        """Resets the dimension of all variables
-           TODO
-        """
-        assert len(new_size) == 3
-        self.shape = tuple(new_size)
+        i = 0
+        keys = list(self._data.keys())
+        for old_key in keys:
+            new_key = "V{:d}".format(i)
+            i += 1
+            self._data[new_key] = self._data.pop(old_key)
 
     def nxyz(self):
         return (self.shape[0] * self.shape[1] * self.shape[2])

--- a/mpstool/img.py
+++ b/mpstool/img.py
@@ -967,7 +967,7 @@ class Image:
 
     # ------ Setters and getters -------
 
-    def set_default_var_name(self):
+    def reset_var_names_to_default(self):
         """Sets default variable names: var_name = ('V0', 'V1',...)."""
         i = 0
         keys = list(self._data.keys())

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -221,6 +221,15 @@ def test_variable(img):
     assert img.get_variables() == ["V0"]
 
 
+def test_default_variable_name(img):
+    data = np.array([[200, 255, 60],
+                     [100, 10, 255],
+                     [250, 100, 0]])
+    img.add_variable("test", data)
+    img.set_default_var_name()
+    assert img.get_variables() == ["V0", "V1"]
+
+
 def test_extract(img):
     img2 = deepcopy(img).extract_variable(["V0"], copy=False)
     assert len(img2.get_variables()) == 1

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -180,11 +180,6 @@ def test_categorize2(img):
     assert img == expected
 
 
-def test_setters(img):
-    img.set_dimension((1, 1, 1))
-    assert img.shape == (1, 1, 1)
-
-
 def test_dimension(img):
     assert img.nxyz() == 9
     assert img.nxy() == 9

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -216,12 +216,13 @@ def test_variable(img):
     assert img.get_variables() == ["V0"]
 
 
-def test_default_variable_name(img):
+def test_reset_default_variable_name(img):
     data = np.array([[200, 255, 60],
                      [100, 10, 255],
                      [250, 100, 0]])
-    img.add_variable("test", data)
-    img.set_default_var_name()
+    img.add_variable("custom_var_name", data)
+    img.reset_var_names_to_default()
+    # default variable names are V0, V1... V<n_variables>
     assert img.get_variables() == ["V0", "V1"]
 
 


### PR DESCRIPTION
The `set_default_var_name` method resets all variables names to V_0, V_1, ..., V_n

It would do nothing before. Now the function is implemented and tested.

I also removed the `set_dimension` method, which was labeled as a work in progress and wasn't doing anything.